### PR TITLE
Fix parsing missing timestamps in XML

### DIFF
--- a/dbbot/reader/robot_results_parser.py
+++ b/dbbot/reader/robot_results_parser.py
@@ -37,8 +37,8 @@ class RobotResultsParser(object):
                 'hash': hash,
                 'imported_at': datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f'),
                 'source_file': test_run.source,
-                'started_at': self._format_robot_timestamp(test_run.suite.starttime),
-                'finished_at': self._format_robot_timestamp(test_run.suite.endtime)
+                'started_at': self._format_robot_timestamp(test_run.suite.starttime) if test_run.suite.starttime else 'NULL',
+                'finished_at': self._format_robot_timestamp(test_run.suite.endtime) if test_run.suite.starttime else 'NULL'
             })
         except IntegrityError:
             test_run_id = self._db.fetch_id('test_runs', {


### PR DESCRIPTION
In some cases suite start/end timestamps maybe not applicable, e.g.
for when XML output is merged from two separate test runs using
rebot.

Thus if start/end timestamp in the output XML is "None" do not crash
but insert "NULL" into the DB.